### PR TITLE
BAU Enforce matching on query string & request body

### DIFF
--- a/lib/coreHandlers.js
+++ b/lib/coreHandlers.js
@@ -91,7 +91,7 @@ const addMocksEndpoint = (request) => {
         headers,
         isDeepEquals,
         callCount: 0,
-        lastUsedDate,
+        lastUsedDate
       })
     })
   })

--- a/lib/coreHandlers.js
+++ b/lib/coreHandlers.js
@@ -24,7 +24,7 @@ const addMocksEndpoint = (request) => {
   if (requestBody.defaultResponse) {
     configuredHandlers.__default__ = Object.assign({}, requestBody.defaultResponse, { callCount: 0 })
   }
-  stubs.forEach(({ predicates, responses, options }) => {
+  stubs.forEach(({ predicates, responses }) => {
     if (!predicates) {
       return errors.push('no predicates provided (we require exactly one)')
     }
@@ -94,11 +94,7 @@ const addMocksEndpoint = (request) => {
         lastUsedDate,
       }
 
-      if (options?.responseIndex) {
-
-      } else {
-        configuredHandlers[method][path].push(handler)
-      }
+      configuredHandlers[method][path].push(handler)
     })
   })
   if (errors.length > 0) {

--- a/lib/coreHandlers.js
+++ b/lib/coreHandlers.js
@@ -24,7 +24,7 @@ const addMocksEndpoint = (request) => {
   if (requestBody.defaultResponse) {
     configuredHandlers.__default__ = Object.assign({}, requestBody.defaultResponse, { callCount: 0 })
   }
-  stubs.forEach(({ predicates, responses }) => {
+  stubs.forEach(({ predicates, responses, options }) => {
     if (!predicates) {
       return errors.push('no predicates provided (we require exactly one)')
     }
@@ -82,7 +82,8 @@ const addMocksEndpoint = (request) => {
         configuredHandlers[method][path] = []
       }
       const lastUsedDate = getCurrentTime()
-      configuredHandlers[method][path].push({
+
+      const handler = {
         statusCode,
         body,
         queryObj: stringifyQueryObject(query),
@@ -90,8 +91,14 @@ const addMocksEndpoint = (request) => {
         headers,
         isDeepEquals,
         callCount: 0,
-        lastUsedDate
-      })
+        lastUsedDate,
+      }
+
+      if (options?.responseIndex) {
+
+      } else {
+        configuredHandlers[method][path].push(handler)
+      }
     })
   })
   if (errors.length > 0) {

--- a/lib/coreHandlers.js
+++ b/lib/coreHandlers.js
@@ -83,7 +83,7 @@ const addMocksEndpoint = (request) => {
       }
       const lastUsedDate = getCurrentTime()
 
-      const handler = {
+      configuredHandlers[method][path].push({
         statusCode,
         body,
         queryObj: stringifyQueryObject(query),
@@ -92,9 +92,7 @@ const addMocksEndpoint = (request) => {
         isDeepEquals,
         callCount: 0,
         lastUsedDate,
-      }
-
-      configuredHandlers[method][path].push(handler)
+      })
     })
   })
   if (errors.length > 0) {

--- a/lib/mockRequestHandling.js
+++ b/lib/mockRequestHandling.js
@@ -17,9 +17,15 @@ function getHandlerForRequest ({ method, url, queryObj, body }) {
 
   if (configuredHandlers[method] && configuredHandlers[method][url] && configuredHandlers[method][url].length > 0) {
     const handlers = configuredHandlers[method][url]
-    const filtered = handlers
+    console.log(method, url, queryObj)
+    console.log('handlers:')
+    console.log(handlers)
+    const filtered1 = handlers
       .filter(conf => objectsMatch(queryObj, conf.queryObj, conf.isDeepEquals))
+    console.log('matching query string', filtered1)
+    const filtered = filtered1
       .filter(conf => objectsMatch(body, conf.bodyObj, conf.isDeepEquals))
+    console.log(filtered)
 
     if (filtered.length > 0) {
       const foundHandler = filtered.sort(leastRecentlyUsedFirst).at(0)
@@ -64,11 +70,14 @@ function getHandlerForRequest ({ method, url, queryObj, body }) {
 }
 
 function objectsMatch (received, configured, exact) {
+  console.log(received, configured, exact)
   if (configured && !received) {
     return false
   }
   if (exact === true) {
-    return objectsExactlyMatch(received, configured)
+    const eq = objectsExactlyMatch(received, configured)
+    console.log(eq)
+    return eq
   }
   if (exact === false) {
     return objectsLooselyMatch(received, configured)
@@ -77,9 +86,12 @@ function objectsMatch (received, configured, exact) {
 }
 
 function objectsExactlyMatch (received, configured) {
-  if (configured === undefined) {
-    return true
+  if ((!received && configured) || (received && !configured)) {
+    return false
   }
+  // if (configured === undefined) {
+  //   return true
+  // }
   return objectsDeepEqual(received, configured)
 }
 

--- a/lib/mockRequestHandling.js
+++ b/lib/mockRequestHandling.js
@@ -17,15 +17,10 @@ function getHandlerForRequest ({ method, url, queryObj, body }) {
 
   if (configuredHandlers[method] && configuredHandlers[method][url] && configuredHandlers[method][url].length > 0) {
     const handlers = configuredHandlers[method][url]
-    console.log(method, url, queryObj)
-    console.log('handlers:')
-    console.log(handlers)
     const filtered1 = handlers
       .filter(conf => objectsMatch(queryObj, conf.queryObj, conf.isDeepEquals))
-    console.log('matching query string', filtered1)
     const filtered = filtered1
       .filter(conf => objectsMatch(body, conf.bodyObj, conf.isDeepEquals))
-    console.log(filtered)
 
     if (filtered.length > 0) {
       const foundHandler = filtered.sort(leastRecentlyUsedFirst).at(0)
@@ -70,14 +65,11 @@ function getHandlerForRequest ({ method, url, queryObj, body }) {
 }
 
 function objectsMatch (received, configured, exact) {
-  console.log(received, configured, exact)
   if (configured && !received) {
     return false
   }
   if (exact === true) {
-    const eq = objectsExactlyMatch(received, configured)
-    console.log(eq)
-    return eq
+    return objectsExactlyMatch(received, configured)
   }
   if (exact === false) {
     return objectsLooselyMatch(received, configured)

--- a/lib/mockRequestHandling.js
+++ b/lib/mockRequestHandling.js
@@ -17,9 +17,8 @@ function getHandlerForRequest ({ method, url, queryObj, body }) {
 
   if (configuredHandlers[method] && configuredHandlers[method][url] && configuredHandlers[method][url].length > 0) {
     const handlers = configuredHandlers[method][url]
-    const filtered1 = handlers
+    const filtered = handlers
       .filter(conf => objectsMatch(queryObj, conf.queryObj, conf.isDeepEquals))
-    const filtered = filtered1
       .filter(conf => objectsMatch(body, conf.bodyObj, conf.isDeepEquals))
 
     if (filtered.length > 0) {
@@ -81,9 +80,6 @@ function objectsExactlyMatch (received, configured) {
   if ((!received && configured) || (received && !configured)) {
     return false
   }
-  // if (configured === undefined) {
-  //   return true
-  // }
   return objectsDeepEqual(received, configured)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,12 @@ export function getCurrentTime () {
 }
 
 export function objectsDeepEqual (l, r, config = {}) {
+  console.log(l, r)
+  if (!l || !r) {
+    console.log(l, r, l === r)
+    return l === r
+  }
+
   const allowArraysInAnyOrder = config?.allowArraysInAnyOrder !== false
   if (Object.keys(l).length !== Object.keys(r).length) {
     return false
@@ -13,7 +19,7 @@ export function objectsDeepEqual (l, r, config = {}) {
       return objectsDeepEqual(l, r, config)
     }
 
-    return r.includes(l)
+    return r === l
   }
 
   if (allowArraysInAnyOrder && Array.isArray(l)) {
@@ -27,12 +33,20 @@ export function objectsDeepEqual (l, r, config = {}) {
     }
     return true
   }
+
   for (const key in l) {
+    console.log(key)
+    console.log(typeof l[key])
     if (typeof l[key] === 'object') {
       if (!objectsDeepEqual(l[key], r[key], config)) {
+        console.log('doesnt match:')
+        console.log(l[key], r[key])
         return false
       }
     } else if (r[key] !== l[key]) {
+      console.log('doesnt match:')
+      console.log(key)
+      console.log(l[key], r[key])
       return false
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,9 +3,7 @@ export function getCurrentTime () {
 }
 
 export function objectsDeepEqual (l, r, config = {}) {
-  console.log(l, r)
   if (!l || !r) {
-    console.log(l, r, l === r)
     return l === r
   }
 
@@ -35,18 +33,11 @@ export function objectsDeepEqual (l, r, config = {}) {
   }
 
   for (const key in l) {
-    console.log(key)
-    console.log(typeof l[key])
     if (typeof l[key] === 'object') {
       if (!objectsDeepEqual(l[key], r[key], config)) {
-        console.log('doesnt match:')
-        console.log(l[key], r[key])
         return false
       }
     } else if (r[key] !== l[key]) {
-      console.log('doesnt match:')
-      console.log(key)
-      console.log(l[key], r[key])
       return false
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.6",
       "license": "MIT",
       "bin": {
-        "run-amock": "bin/run"
+        "run-amock": "bin/run.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.6",
   "type": "module",
   "scripts": {
-    "test": "node spec/all.spec.js"
+    "test": "node spec/all.spec.js",
+    "dev": "./bin/run.js --port=8000"
   },
   "bin": {
     "run-amock": "bin/run.js"

--- a/spec/debugger.spec.js
+++ b/spec/debugger.spec.js
@@ -169,7 +169,8 @@ describe('equality-with-mountebank', () => {
 
     await fetch(mockedHttpBaseUrl + '/example?page=1&status=failed2-this-will-not-be-matched', {
       headers: {
-        'X-Something-Custom': 'abcdefg'
+        'X-Something-Custom': 'abcdefg',
+        'user-agent': 'node'
       }
     })
 


### PR DESCRIPTION
### What
 - When a query string or request body is provided in a request, this currently does not require a handler to be configured with a matching query/body for the handler to match the request
 - This updates this behaviour to enforce matching only on handlers with a matching configured query/body when `deepEquals` is true