### PR TITLE
PP-12416: Allow null in request bodies

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -143,9 +147,9 @@
         "filename": "spec/equality-with-mountebank.spec.js",
         "hashed_secret": "6cab9fe55715045f4b8005e0f2a282005caacf52",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 718
       }
     ]
   },
-  "generated_at": "2024-10-15T12:29:30Z"
+  "generated_at": "2025-01-27T14:55:50Z"
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,9 @@ export function getCurrentTime () {
 
 export function objectsDeepEqual (l, r, config = {}) {
   const allowArraysInAnyOrder = config?.allowArraysInAnyOrder !== false
+  if ( l === null || l === undefined || r === null || r === undefined ){
+    return l === r
+  }
   if (Object.keys(l).length !== Object.keys(r).length) {
     return false
   }
@@ -28,7 +31,7 @@ export function objectsDeepEqual (l, r, config = {}) {
     return true
   }
   for (const key in l) {
-    if (typeof l[key] === 'object') {
+    if (typeof l[key] === 'object' && l[key] !== null) {
       if (!objectsDeepEqual(l[key], r[key], config)) {
         return false
       }

--- a/spec/objectsDeepEqual.spec.js
+++ b/spec/objectsDeepEqual.spec.js
@@ -124,4 +124,41 @@ describe('objectDeepEqual', () => {
       ]
     })
   })
+  it('should match on null and undefined', () => {
+    const basis = {
+      valueOne: 'one',
+      valueNull: null,
+      valueUndefined: undefined
+    }
+    expectMatch(basis, {
+      valueNull: null,
+      valueOne: 'one',
+      valueUndefined: undefined
+    })
+    expectNotToMatch(basis, {
+      valueNull: 'Value',
+      valueOne: 'one',
+      valueUndefined: undefined
+    })
+    expectNotToMatch(basis, {
+      valueNull: undefined,
+      valueOne: 'one',
+      valueUndefined: undefined
+    })
+    expectNotToMatch(basis, {
+      valueNull: null,
+      valueOne: null,
+      valueUndefined: undefined
+    })
+    expectNotToMatch(basis, {
+      valueNull: null,
+      valueOne: 'one',
+      valueUndefined: 'value'
+    })
+    expectNotToMatch(basis, {
+      valueNull: null,
+      valueOne: 'one',
+      valueUndefined: null
+    })
+  })
 })


### PR DESCRIPTION
While writing tests for Card Payment setting update pages we discovered that Run Amock did not handle request bodies containing `null` values.

This PR corrects this, also handling similar issues with `undefined`.

Pair: @nataliecarey 