### PR TITLE
PP-13557: enable all projects to use latest release

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,23 +133,23 @@
         "filename": "spec/equality-with-mountebank.spec.js",
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 588
       },
       {
         "type": "Hex High Entropy String",
         "filename": "spec/equality-with-mountebank.spec.js",
         "hashed_secret": "7bb363901b8a686a4d3e1949032e469901cddaa8",
         "is_verified": false,
-        "line_number": 535
+        "line_number": 595
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "spec/equality-with-mountebank.spec.js",
         "hashed_secret": "6cab9fe55715045f4b8005e0f2a282005caacf52",
         "is_verified": false,
-        "line_number": 718
+        "line_number": 778
       }
     ]
   },
-  "generated_at": "2025-01-27T14:55:50Z"
+  "generated_at": "2025-02-04T12:01:22Z"
 }

--- a/lib/coreHandlers.js
+++ b/lib/coreHandlers.js
@@ -82,7 +82,6 @@ const addMocksEndpoint = (request) => {
         configuredHandlers[method][path] = []
       }
       const lastUsedDate = getCurrentTime()
-
       configuredHandlers[method][path].push({
         statusCode,
         body,

--- a/lib/httpServer.js
+++ b/lib/httpServer.js
@@ -82,7 +82,7 @@ function issueErrorResponse (err, responseInitiated, res) {
 
 function queryObjectFromString (queryString) {
   if (!queryString || queryString === '') {
-    return undefined
+    return {}
   }
   return Object.fromEntries((queryString || '')
     .split('&')

--- a/lib/mockRequestHandling.js
+++ b/lib/mockRequestHandling.js
@@ -77,8 +77,8 @@ function objectsMatch (received, configured, exact) {
 }
 
 function objectsExactlyMatch (received, configured) {
-  if ((!received && configured) || (received && !configured)) {
-    return false
+  if (configured === undefined) {
+    return true
   }
   return objectsDeepEqual(received, configured)
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,10 +3,6 @@ export function getCurrentTime () {
 }
 
 export function objectsDeepEqual (l, r, config = {}) {
-  if (!l || !r) {
-    return l === r
-  }
-
   const allowArraysInAnyOrder = config?.allowArraysInAnyOrder !== false
   if ( l === null || l === undefined || r === null || r === undefined ){
     return l === r
@@ -20,7 +16,7 @@ export function objectsDeepEqual (l, r, config = {}) {
       return objectsDeepEqual(l, r, config)
     }
 
-    return r === l
+    return r.includes(l)
   }
 
   if (allowArraysInAnyOrder && Array.isArray(l)) {
@@ -34,7 +30,6 @@ export function objectsDeepEqual (l, r, config = {}) {
     }
     return true
   }
-
   for (const key in l) {
     if (typeof l[key] === 'object' && l[key] !== null) {
       if (!objectsDeepEqual(l[key], r[key], config)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.8",
       "license": "MIT",
       "bin": {
-        "run-amock": "bin/run.js"
+        "run-amock": "bin/run"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.8",
   "type": "module",
   "scripts": {
-    "test": "node spec/all.spec.js",
-    "dev": "./bin/run.js --port=8000"
+    "test": "node spec/all.spec.js"
   },
   "bin": {
     "run-amock": "bin/run.js"

--- a/spec/debugger.spec.js
+++ b/spec/debugger.spec.js
@@ -169,7 +169,14 @@ describe('equality-with-mountebank', () => {
 
     await fetch(mockedHttpBaseUrl + '/example?page=1&status=failed2-this-will-not-be-matched', {
       headers: {
-        'X-Something-Custom': 'abcdefg'
+        host: 'localhost:9999',
+        connection: 'keep-alive',
+        accept: '*/*',
+        'accept-language': '*',
+        'sec-fetch-mode': 'cors',
+        'user-agent': 'node',
+        'x-something-custom': 'abcdefg',
+        'accept-encoding': 'gzip, deflate'
       }
     })
 

--- a/spec/debugger.spec.js
+++ b/spec/debugger.spec.js
@@ -169,8 +169,7 @@ describe('equality-with-mountebank', () => {
 
     await fetch(mockedHttpBaseUrl + '/example?page=1&status=failed2-this-will-not-be-matched', {
       headers: {
-        'X-Something-Custom': 'abcdefg',
-        'user-agent': 'node'
+        'X-Something-Custom': 'abcdefg'
       }
     })
 

--- a/spec/equality-with-mountebank.spec.js
+++ b/spec/equality-with-mountebank.spec.js
@@ -276,6 +276,66 @@ testRunConfigs.forEach(config => {
       assert.equal(404, successResult.status, `Expected a failure response from [${fullMockUrl}], got a [${successResult.status}] for query string [${queryString}]`)
     }))
   })
+  it(`should be able to distinguish between the presence and absence of a query string (option A) (${config.name})`, async () => {
+    const url = '/example'
+    await setupImposters(config, {
+      port: mockPort,
+      protocol: 'http',
+      defaultResponse: { statusCode: 404, body: 'Default 404', headers: {} },
+      stubs: [
+        {
+          name: `With no query string`,
+          predicates: [
+            {
+              deepEquals: {
+                method: 'GET',
+                path: url,
+                query: {}
+              }
+            }
+          ],
+          responses: [
+            {
+              is: {
+                statusCode: 301
+              }
+            }
+          ]
+        },
+        {
+          name: `With a query string`,
+          predicates: [
+            {
+              deepEquals: {
+                method: 'GET',
+                path: url,
+                query: {
+                  a: 'b'
+                }
+              }
+            }
+          ],
+          responses: [
+            {
+              is: {
+                statusCode: 302
+              }
+            }
+          ]
+        }
+      ]
+    })
+
+    const fullMockUrl = config.mockedHttpBaseUrl + url
+    const noQueryStringResponse = await fetch(fullMockUrl)
+
+    assert.equal(301, noQueryStringResponse.status, `Expected a 301 response from [${fullMockUrl}], got a [${noQueryStringResponse.status}] for no query string`)
+
+    const queryString = 'a=b'
+    const withQueryStringResponse = await fetch(fullMockUrl + '?' + queryString)
+
+    assert.equal(302, withQueryStringResponse.status, `Expected a 302 response from [${fullMockUrl}], got a [${withQueryStringResponse.status}] for query string [${queryString}]`)
+  })
   it(`should type correct query strings (${config.name})`, async () => {
     const url = '/example'
     await setupImposters(config, {


### PR DESCRIPTION
There are two commits here, the first rolls back the breaking change and the second allows the use of empty objects to specify (when using `deepEquals`) that the body/query must be empty.

This matches the Mountebank approach and is therefore compatible with our existing Cypress Tests.

A test has been added to the `equality-with-mountebank.spec.js` test which can be run against Mountebank and Run Amock, it passes in both cases.