### PR TITLE
PP-13557/BAU: Add dev script

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'path'
+import cp from 'child_process'
+
+const [_, __, ...args] = process.argv
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+console.log('running in dev mode with params:', args)
+
+fs.watch(projectRoot, {
+  recursive: true
+}, () => {
+  deboucedServerRestart()
+})
+
+let runningServerProcess
+let serverProcessIsRestarting = false
+let shouldRestartImmediatelyAfterRestart = false
+
+async function deboucedServerRestart() {
+  if (serverProcessIsRestarting) {
+    shouldRestartImmediatelyAfterRestart = true
+    return
+  }
+  serverProcessIsRestarting = true
+  await stopServerIfNecessary()
+  await new Promise(resolve => setTimeout(resolve, 50)) // to handle multiple simultanious changes, e.g. `.swp` files
+  await startServer()
+  if (shouldRestartImmediatelyAfterRestart) {
+    process.nextTick(deboucedServerRestart)
+  }
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    shouldRestartImmediatelyAfterRestart = false
+    if (runningServerProcess) {
+      console.error('cannot start server, one is already running!!')
+      return
+    }
+    runningServerProcess = cp.spawn('./bin/run.js', args, {})
+    const listener = (data) => {
+      const str = data.toString();
+      if (str.trim() === 'starting run-amock http server') {
+        serverProcessIsRestarting = false
+        runningServerProcess.stdout.off('data', listener)
+        resolve()
+      }
+    };
+    runningServerProcess.stdout.on('data', listener)
+    runningServerProcess.stdout.pipe(process.stdout)
+    runningServerProcess.on('close', (...a) => {
+      runningServerProcess = undefined
+    })
+  })
+}
+
+function stopServerIfNecessary() {
+  if (!runningServerProcess) {
+    return
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      runningServerProcess.off('close', listener)
+      reject(new Error('Waited too long for the server to shut down'))
+    }, 2000)
+    const listener = () => {
+      runningServerProcess = undefined
+      clearTimeout(timeout)
+      resolve()
+    };
+    runningServerProcess.once('close', listener)
+    runningServerProcess.kill('SIGINT')
+
+  })
+}
+
+deboucedServerRestart()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.9",
   "type": "module",
   "scripts": {
-    "test": "node spec/all.spec.js"
+    "test": "node spec/all.spec.js",
+    "dev": "bin/dev.js"
   },
   "bin": {
     "run-amock": "bin/run.js"


### PR DESCRIPTION
We had a PR review discussion about dev scripts, my perspective was that we should only do that if we have auto-restarts.

Run Amock has a policy of not using any dependencies which means that tools like `nodemon` aren't available.

This PR adds a dev script written in pure Node which auto-restarts when changes are made.

There are no tests for this as:

a) The tests would likely be extremely tightly coupled with the implementation
or
b) The tests would require a level of testing that doesn't exist in this project
c) As this is only used during local development any issues that come up with it will affect the process of working on Run Amock and not the deliverable project

I've marked this as both PP-13557 because that's where the comment came from and as BAU as there isn't a specific ticket for this feature.

I will not be upset if this doesn't get merged.

Usage:

```
npm run dev
```

```
npm run dev -- --debug
```

(note the `--` that tells NPM to pass through the rest of the arguments)

```
npm run dev -- --port=8000
```