### PR TITLE
PP-14551 enable trusted publishing oidc

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -26,8 +27,8 @@ jobs:
           cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
+      - name: Upgrade npm # Required so we can use OIDC
+        run: npm install -g npm@11.6.0
         run: npm ci
       - name: Publish package
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
- Updating github actions
- Updating to use OIDC
- Removing npm auth token settings
- To use OIDC we need NPM 11.x